### PR TITLE
Prevent suggestionproviderfix:test_air from being added to the registry in production builds. Also removed the artificial version limitation in fabric.mod.json.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,126 @@
+# Maven
+# https://github.com/github/gitignore/blob/master/Maven.gitignore
+# --------
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+
+# Eclipse m2e generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# Gradle
+# https://github.com/github/gitignore/blob/master/Gradle.gitignore
+# --------
+.gradle
+**/build/
+!src/**/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
+# Cache of project
+.gradletasknamecache
+
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# IntelliJ IDEA
+# https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore
+# --------
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser

--- a/src/main/java/safro/suggestion/provider/fabric/SuggestionProviderFabric.java
+++ b/src/main/java/safro/suggestion/provider/fabric/SuggestionProviderFabric.java
@@ -8,11 +8,11 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
 public class SuggestionProviderFabric implements ModInitializer {
-
-	public static final Block TEST_AIR = new Block(AbstractBlock.Settings.copy(Blocks.AIR));
-
 	@Override
 	public void onInitialize() {
-		Registry.register(Registry.BLOCK, new Identifier("suggestionproviderfix", "test_air"), TEST_AIR);
+		// Uncommenting the below code will add suggestionproviderfix:test_air to the registry, which is useful during development to verify that SuggestionProviderFabric is working correctly.
+		// ※ WARNING: This should NEVER be shipped in production!
+
+		// Registry.register(Registry.BLOCK, new Identifier("suggestionproviderfix", "test_air"), new Block(AbstractBlock.Settings.copy(Blocks.AIR)));
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,7 +30,7 @@
   "depends": {
     "fabricloader": ">=0.11.3",
     "fabric": "*",
-    "minecraft": "1.18.x",
+    "minecraft": ">=1.18",
     "java": ">=17"
   }
 }


### PR DESCRIPTION
Prevent `suggestionproviderfix:test_air` from being added to the registry in production builds.

This should _never_ occur for a pure client-side mod, and it is only useful for development/testing purposes, anyway.

I've also [backported this change to 1.17.1 in the `1.17.1` branch of my fork](https://github.com/akemin-dayo/SuggestionProviderFabric/tree/1.17.1)!

That being said, GitHub doesn't support being able to create new branches on the upstream repo of a PR, so please just manually create a branch named `1.17.1` (from commit SHA-1 f619c1d1c3180b15a81122ac8a6a7f8c0c2d443d) and merge in the changes from my fork. (Or I can open another PR if you'd prefer.)

---

I've also removed the artificial version limitation in `fabric.mod.json`, as the single mixin in this mod is so simple that updates are unlikely to break it. This allows users to try to load SuggestionProviderFix into future versions. (I've confirmed that this mod works with 1.19.)